### PR TITLE
Subscribe to StackExchange updates on clientside

### DIFF
--- a/stackoh/server.py
+++ b/stackoh/server.py
@@ -37,4 +37,4 @@ def tags_request(message):
 if __name__ == "__main__":
     import os
 
-    socketio.run(app, host=os.environ['IP'], port=int(os.environ['PORT']), debug=True)
+    socketio.run(app, host=os.environ['IP'], port=int(os.environ['PORT']))

--- a/stackoh/server.py
+++ b/stackoh/server.py
@@ -37,4 +37,4 @@ def tags_request(message):
 if __name__ == "__main__":
     import os
 
-    socketio.run(app, host=os.environ['IP'], port=int(os.environ['PORT']))
+    socketio.run(app)

--- a/stackoh/templates/index.html
+++ b/stackoh/templates/index.html
@@ -22,6 +22,13 @@
 
             <div class="row">
                 <div class="col-md-8 col-md-offset-2">
+                    <h1>Live Global Update
+                    <div id="global-plot"></div>
+                </div>
+            </div>
+            <div class="row">
+                <div class="col-md-8 col-md-offset-2">
+                    <h1>Local Inquiry</h1>
                     <div id="plot"></div>
                 </div>
             </div>
@@ -56,6 +63,21 @@
             }
             console.log(counts);
             // Redraw graph
+
+            var x = Object.keys(counts);
+            var y = Array();
+            for (var i in counts)
+            {
+                y.push(counts[i]);
+            }
+
+            plot_data = [ {
+                x: x,
+                y: y,
+                type: 'bar'
+            } ];
+
+            Plotly.newPlot("global-plot", plot_data);
         };
 
         socket.on("tags_data", function(data)

--- a/stackoh/templates/index.html
+++ b/stackoh/templates/index.html
@@ -32,7 +32,31 @@
         <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
         <script src="https://cdn.socket.io/socket.io-1.4.5.js"></script>
         <script>
-        var socket = io();
+        var socket = io('http://' + document.domain + ':' + location.port);
+
+        var so_socket = new WebSocket("ws://qa.sockets.stackexchange.com/");
+        var counts = Object();
+
+        so_socket.onopen = function()
+        {
+            so_socket.send("155-questions-active");
+        };
+        so_socket.onmessage = function(raw_data)
+        {
+            // get community from data
+            var data = JSON.parse(JSON.parse(raw_data["data"])["data"]);
+            var community = data["apiSiteParameter"];
+            if (community in counts)
+            {
+                counts[community] += 1;
+            }
+            else
+            {
+                counts[community] = 1;
+            }
+            console.log(counts);
+            // Redraw graph
+        };
 
         socket.on("tags_data", function(data)
         {

--- a/stackoh/templates/index.html
+++ b/stackoh/templates/index.html
@@ -7,7 +7,7 @@
     <body>
         <div class="jumbotron">
             <div class="container">
-                <h1>StackOh <small>Ohhhhh yeaaahhh</small></h1>
+                <h1>StackOhYeaaaaa</h1>
             </div>
         </div>
         <div class="container">
@@ -41,9 +41,13 @@
         <script>
         var socket = io('http://' + document.domain + ':' + location.port);
 
+        // connect to StackExchange sockets
         var so_socket = new WebSocket("ws://qa.sockets.stackexchange.com/");
         var counts = Object();
 
+        // to begin feed we notify that we are looking for all active questions from all communities
+        // the "API" (no official one exists) can be found here
+        // http://meta.stackexchange.com/questions/218343/how-do-the-stack-exchange-websockets-work-what-are-all-the-options-you-can-send
         so_socket.onopen = function()
         {
             so_socket.send("155-questions-active");


### PR DESCRIPTION
fixes #8 

This PR adds a live plot (fed by websockets) of incoming questions to StackExchange -- it plots the count of questions each community has received, and is absolutely baller. We've watched it for hours.

The client is directly connected to StackExchange via WebSockets -- so all computation and data transfer happens without consulting our server. This may change later if we wish to have a pre-computed window of most recent data to send to the client when they first connect so they don't just start with a blank graph

![image](https://cloud.githubusercontent.com/assets/7263654/15802393/8380cc9e-2a65-11e6-8aab-27a6cb12ef91.png)
